### PR TITLE
Remove the Pixi entrypoint in Trame applications

### DIFF
--- a/template_sources/dockerfiles/{% if application_type != 'Minimal' %}Dockerfile{% endif %}.j2
+++ b/template_sources/dockerfiles/{% if application_type != 'Minimal' %}Dockerfile{% endif %}.j2
@@ -49,7 +49,7 @@ RUN curl -fsSL https://pixi.sh/install.sh | sh
 ENV PATH="/root/.pixi/bin:${PATH}"
 RUN pixi install -e production
 SHELL [ "pixi", "run", "-e", "production" ]
-ENTRYPOINT [ "pixi", "run", "-e", "production", "--manifest-path", "/src/pyproject.toml" ]
+ENTRYPOINT []
 
 RUN pixi add --pypi supervisor
 RUN scripts/generate_static_client.sh

--- a/template_sources/dockerfiles/{% if application_type != 'Minimal' %}Dockerfile{% endif %}.j2
+++ b/template_sources/dockerfiles/{% if application_type != 'Minimal' %}Dockerfile{% endif %}.j2
@@ -54,7 +54,7 @@ ENTRYPOINT []
 RUN pixi add --pypi supervisor
 RUN scripts/generate_static_client.sh
 
-RUN chmod og+rwX -R /src
+RUN chmod og+rwX -R /root /src
 
 CMD [ "supervisord" ]
 {%- endif -%}

--- a/template_sources/xml/tool.xml.j2
+++ b/template_sources/xml/tool.xml.j2
@@ -19,7 +19,7 @@
         <environment_variable name="EP_PATH" inject="entry_point_path_for_label">app_entry</environment_variable>
     </environment_variables>
      <command><![CDATA[
-        {% if application_type in ['Nova Application', 'Tutorial'] and framework == 'Trame' %}supervisord > >(tee -a $output) 2> >(tee -a $output >&2)
+        {% if application_type in ['Nova Application', 'Tutorial'] and framework == 'Trame' %}pixi run -e production --manifest-path /src/pyproject.toml supervisord > >(tee -a $output) 2> >(tee -a $output >&2)
         {% elif application_type == 'Minimal' %} echo "Container ran successfully."
         {% else %}python3.10 -m {{ python_package | replace('-', '_') }} > >(tee -a $output) 2> >(tee -a $output >&2){% endif %}
     ]]></command>

--- a/template_sources/xml/tool.xml.j2
+++ b/template_sources/xml/tool.xml.j2
@@ -19,7 +19,7 @@
         <environment_variable name="EP_PATH" inject="entry_point_path_for_label">app_entry</environment_variable>
     </environment_variables>
      <command><![CDATA[
-        {% if application_type in ['Nova Application', 'Tutorial'] and framework == 'Trame' %}pixi run -e production --manifest-path /src/pyproject.toml supervisord > >(tee -a $output) 2> >(tee -a $output >&2)
+        {% if application_type in ['Nova Application', 'Tutorial'] and framework == 'Trame' %}pixi run -e production -m /src/pyproject.toml supervisord > >(tee -a $output) 2> >(tee -a $output >&2)
         {% elif application_type == 'Minimal' %} echo "Container ran successfully."
         {% else %}python3.10 -m {{ python_package | replace('-', '_') }} > >(tee -a $output) 2> >(tee -a $output >&2){% endif %}
     ]]></command>


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
This removes the Pixi ENTRYPOINT in our Trame Dockerfiles. To get equivalent functionality, we need to give the Trame user access to /root in the image so that they can directly call the `pixi` command and add the `pixi` command to the default tool XML file.

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
