### PR TITLE
Add documentation URL to pyproject.toml and use it in tool.xml

### DIFF
--- a/template_sources/scripts/{% if application_type in ['Nova Application', 'NDIP Tool', 'Tutorial'] %}xml_utils.py{% endif %}.j2
+++ b/template_sources/scripts/{% if application_type in ['Nova Application', 'NDIP Tool', 'Tutorial'] %}xml_utils.py{% endif %}.j2
@@ -80,10 +80,10 @@ def deploy_production_xml() -> None:
                         break
 
                 if line.startswith("Documentation = "):
-                    documentation = line.split("=")[1].strip().strip("\"'")
+                    docs_link = line.split("=")[1].strip().strip("\"'")
         except Exception:
             version = "latest"
-            documentation = ""
+            docs_link = ""
 
         # Construct the full Docker image URL
         container_registry = "savannah.ornl.gov"

--- a/template_sources/scripts/{% if application_type in ['Nova Application', 'NDIP Tool', 'Tutorial'] %}xml_utils.py{% endif %}.j2
+++ b/template_sources/scripts/{% if application_type in ['Nova Application', 'NDIP Tool', 'Tutorial'] %}xml_utils.py{% endif %}.j2
@@ -71,15 +71,19 @@ def deploy_production_xml() -> None:
         pipeline_url = None
         check_uncommitted_changes()
 
-        # Get current project version for container tag
+        # Get current project version for container tag and documentation link
         try:
             with open("pyproject.toml", "r") as f:
                 for line in f:
                     if line.startswith("version = "):
                         version = line.split("=")[1].strip().strip("\"'")
                         break
+
+                if line.startswith("Documentation = "):
+                    documentation = line.split("=")[1].strip().strip("\"'")
         except Exception:
             version = "latest"
+            documentation = ""
 
         # Construct the full Docker image URL
         container_registry = "savannah.ornl.gov"
@@ -176,6 +180,7 @@ def deploy_production_xml() -> None:
             container_path = "ndip/tool-sources/{{ tool_category }}/{{ project_name.lower().replace(' ', '-').replace('_', '-') }}"
 
             xml_content = xml_content.replace("@TOOL_VERSION@", version)
+            xml_content = xml_content.replace("@TOOL_DOCS_LINK@", docs_link)
             xml_content = xml_content.replace("@CONTAINER_REGISTRY@", container_registry)
             xml_content = xml_content.replace("@CONTAINER_PATH@", container_path)
             xml_content = xml_content.replace("@CONTAINER_TAG@", version)

--- a/template_sources/scripts/{% if application_type in ['Nova Application', 'NDIP Tool', 'Tutorial'] %}xml_utils_prototype.py{% endif %}.j2
+++ b/template_sources/scripts/{% if application_type in ['Nova Application', 'NDIP Tool', 'Tutorial'] %}xml_utils_prototype.py{% endif %}.j2
@@ -49,10 +49,10 @@ def push_tool_xml_prototype() -> None:
                         break
 
                 if line.startswith("Documentation = "):
-                    documentation = line.split("=")[1].strip().strip("\"'")
+                    docs_link = line.split("=")[1].strip().strip("\"'")
         except Exception:
             version = "latest"
-            documentation = ""
+            docs_link = ""
 
         # Temporary directory for Galaxy tools repo
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/template_sources/scripts/{% if application_type in ['Nova Application', 'NDIP Tool', 'Tutorial'] %}xml_utils_prototype.py{% endif %}.j2
+++ b/template_sources/scripts/{% if application_type in ['Nova Application', 'NDIP Tool', 'Tutorial'] %}xml_utils_prototype.py{% endif %}.j2
@@ -40,12 +40,19 @@ def push_tool_xml_prototype() -> None:
             print(f"Error: Tool XML file not found at {xml_source}", file=sys.stderr)
             sys.exit(1)
 
-        # Get current project version for container tag
-        with open("pyproject.toml", "r") as f:
-            for line in f:
-                if line.startswith("version = "):
-                    version = line.split("=")[1].strip().strip("\"'")
-                    break
+        # Get current project version for container tag and documentation link
+        try:
+            with open("pyproject.toml", "r") as f:
+                for line in f:
+                    if line.startswith("version = "):
+                        version = line.split("=")[1].strip().strip("\"'")
+                        break
+
+                if line.startswith("Documentation = "):
+                    documentation = line.split("=")[1].strip().strip("\"'")
+        except Exception:
+            version = "latest"
+            documentation = ""
 
         # Temporary directory for Galaxy tools repo
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -94,6 +101,7 @@ def push_tool_xml_prototype() -> None:
                 print("Continuing without Docker image verification...", file=sys.stderr)
 
             xml_content = xml_content.replace("@TOOL_VERSION@", version)
+            xml_content = xml_content.replace("@TOOL_DOCS_LINK@", docs_link)
             xml_content = xml_content.replace("@CONTAINER_REGISTRY@", container_registry)
             xml_content = xml_content.replace("@CONTAINER_PATH@", container_path)
             xml_content = xml_content.replace("@CONTAINER_TAG@", prototype_image_tag)

--- a/template_sources/xml/tool.xml.j2
+++ b/template_sources/xml/tool.xml.j2
@@ -1,7 +1,7 @@
 {% if application_type in ['Nova Application', 'Tutorial'] %}
-<tool id="nova-{{ project_name.lower().replace(' ', '-').replace('_', '-') }}-prototype" tool_type="interactive" name="{{ project_name }}" version="@TOOL_VERSION@" profile="22.01">
+<tool id="nova-{{ project_name.lower().replace(' ', '-').replace('_', '-') }}-prototype" tool_type="interactive" name="{{ project_name }}" documentation="@TOOL_DOCS_LINK@" version="@TOOL_VERSION@" profile="22.01">
 {% else %}
-<tool id="{{ project_name.lower().replace(' ', '-').replace('_', '-') }}-prototype" name="{{ project_name }}" version="@TOOL_VERSION@" profile="22.01">
+<tool id="{{ project_name.lower().replace(' ', '-').replace('_', '-') }}-prototype" name="{{ project_name }}" version="@TOOL_VERSION@" documentation="@TOOL_DOCS_LINK@" profile="22.01">
 {% endif %}
     <description>{{ project_name }} - A tool generated using the NOVA Application Template</description>
     <requirements>
@@ -17,6 +17,8 @@
         <environment_variable name="GALAXY_API_KEY" inject="api_key"/>
         <environment_variable name="HISTORY_ID">$__history_id__</environment_variable>
         <environment_variable name="EP_PATH" inject="entry_point_path_for_label">app_entry</environment_variable>
+        <environment_variable name="NOVA_TOOL_VERSION">@TOOL_VERSION@</environment_variable>
+        <environment_variable name="NOVA_TOOL_DOCS_LINK">@TOOL_DOCS_LINK@</environment_variable>
     </environment_variables>
      <command><![CDATA[
         {% if application_type in ['Nova Application', 'Tutorial'] and framework == 'Trame' %}pixi run -e production -m /src/pyproject.toml supervisord > >(tee -a $output) 2> >(tee -a $output >&2)

--- a/template_sources/{% if application_type != 'Minimal' %}pyproject.toml{% endif %}.j2
+++ b/template_sources/{% if application_type != 'Minimal' %}pyproject.toml{% endif %}.j2
@@ -8,6 +8,9 @@ license = "MIT"
 keywords = ["NDIP", "NOVA", "python"]
 requires-python = ">=3.10,<3.14"
 
+[project.urls]
+Documentation = ""
+
 [tool.pixi.workspace]
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64"]


### PR DESCRIPTION
## Summary of Changes
<!-- Summarize the changes made in this PR -->
This adds the ability to specify a documentation URL in pyproject.toml that integrates with nova-trame and nova-dashboard to display the URL to users.

We could consider automatically creating tool documentation links that point to https://ndip.ornl.gov/docs/user_guide/tools/, but I'm not sure if this is what we want. Would be interested to hear your thoughts on this subject!

## Checklist
<!-- Ensure all relevant checks are completed before requesting a review -->
- [x] The PR has a clear and concise title
- [x] Code is self-documented and follows [style guidelines](https://calvera.ornl.gov/docs/dev/project_management/style_guidelines/).
- [x] Automated tests are written and pass successfully.
- [x] Regression tests (e.g. manually triggered system tests, manual GUI/tool tests, ...) are performed to make sure the PR does not break anything (when applicable)
- [x] Readme file is present and up-to-date.

## Documentation Updates
<!-- Indicate whether any external documentation was updated -->

## Additional Notes
<!-- Provide any additional information that might be relevant -->
